### PR TITLE
Add pilot configurations for VDN and QMIX using total timesteps

### DIFF
--- a/experiments/config/pilot_runs/ippo_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/ippo_rnn_road_env.yaml
@@ -53,7 +53,7 @@
 
 # model checkpointing (will be saved in hydra dir)
 "SAVE_CHECKPOINTS": True # save checkpoints
-"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tipp: set to same value or fraction of TEST_INTERVAL.
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tip: set to same value or fraction of TEST_INTERVAL.
 
 # precision
 "DOUBLE_PRECISION_MODE": False # use double precision for the environment

--- a/experiments/config/pilot_runs/mappo_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/mappo_rnn_road_env.yaml
@@ -53,7 +53,7 @@
 
 # checkpointing
 "SAVE_CHECKPOINTS": True # save checkpoints
-"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tipp: set to same value or fraction of TEST_INTERVAL.
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tip: set to same value or fraction of TEST_INTERVAL.
 
 # precision
 "DOUBLE_PRECISION_MODE": False # use double precision for the environment

--- a/experiments/config/pilot_runs/pqn_vdn_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/pqn_vdn_rnn_road_env.yaml
@@ -1,0 +1,67 @@
+# Convergence pilot for PQN-VDN on the IMP-act road env.
+# Algorithm hyperparameters from the PQN paper SMAX config.
+
+"TOTAL_TIMESTEPS": 50_000_000
+"NUM_ENVS": 128
+"NUM_STEPS": 51
+"MEMORY_WINDOW": 4
+"HIDDEN_SIZE": 512
+"NUM_LAYERS": 2
+"NORM_INPUT": True
+"NORM_TYPE": "batch_norm"
+"EPS_START": 1.0
+"EPS_FINISH": 0.01
+"EPS_DECAY": 0.1
+"MAX_GRAD_NORM": 1
+"NUM_MINIBATCHES": 16
+"NUM_EPOCHS": 4
+"LR": 0.00025
+"LR_LINEAR_DECAY": False
+"GAMMA": 0.99
+"LAMBDA": 0.85
+
+# ENV
+"ENV_NAME": "road_env"
+"ENV_KWARGS":
+  "map_name": "ToyExample-v2"
+  "encoding_type": "none"       # can be binary, one-hot, sinusoidal or none
+  "include_extra_observations":
+    "segment_lengths": True     # Length of the segments
+    "volumes": True             # Volumes of the vehicles on the segment normalized by the segment capacity
+    "capacity": False           # Capacity of the segments
+
+"REW_SCALE": 1e-8
+
+# evaluate
+"TEST_DURING_TRAINING": True
+"TEST_INTERVAL": 0.01 # as a fraction of updates
+"TEST_NUM_STEPS": 50
+"TEST_NUM_ENVS": 1000
+
+"ALG_NAME": "pqn_rnn"
+
+############ global params ############
+
+# experiment params
+"NUM_SEEDS": 1 # number of vmapped seeds
+"SEED": "random"
+
+"HYP_TUNE": False # perform hyp tune
+
+# wandb params
+"ENTITY": "imp-act"
+"PROJECT": "jaxMARL-pqn-test"
+"WANDB_MODE": "online"
+"WANDB_LOG_ALL_SEEDS": False # will log separately the vmapped seeds
+
+# checkpointing
+"SAVE_CHECKPOINTS": True # save checkpoints
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tip: set to same value or fraction of TEST_INTERVAL.
+
+# precision
+"DOUBLE_PRECISION_MODE": False # use double precision for the environment
+
+# hydra params
+hydra:
+  run:
+    dir: outputs/${ENV_KWARGS.map_name}/${ALG_NAME}/${now:%Y-%m-%d_%H-%M-%S.%f}

--- a/experiments/config/pilot_runs/qmix_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/qmix_rnn_road_env.yaml
@@ -38,7 +38,7 @@
 # evaluate
 "TEST_DURING_TRAINING": True
 "TEST_INTERVAL": 0.01 # as a fraction of updates
-"TEST_NUM_STEPS": 51
+"TEST_NUM_STEPS": 50
 "TEST_NUM_ENVS": 1000
 
 "ALG_NAME": "qmix_rnn"
@@ -59,7 +59,7 @@
 
 # checkpointing
 "SAVE_CHECKPOINTS": True # save checkpoints
-"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tipp: set to same value or fraction of TEST_INTERVAL.
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tip: set to same value or fraction of TEST_INTERVAL.
 
 # precision
 "DOUBLE_PRECISION_MODE": False # use double precision for the environment

--- a/experiments/config/pilot_runs/qmix_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/qmix_rnn_road_env.yaml
@@ -1,0 +1,70 @@
+# Convergence pilot for QMIX on the IMP-act road env.
+# Hyperparameters from JaxMARL paper (Rutherford et al., NeurIPS 2024 D&B Track), 
+# Supplemental Table 8 ("Table 8: Q-Learning hyperparameters for MPE, SMAX and Overcooked")
+
+"TOTAL_TIMESTEPS": 50_000_000
+"NUM_ENVS": 16
+"NUM_STEPS": 128
+"BUFFER_SIZE": 5000
+"BUFFER_BATCH_SIZE": 32
+"HIDDEN_SIZE": 512
+"EPS_START": 1.0
+"EPS_FINISH": 0.05
+"EPS_DECAY": 0.1 # percentage of updates
+"MAX_GRAD_NORM": 10
+"TARGET_UPDATE_INTERVAL": 10
+"TAU": 1.0
+"NUM_EPOCHS": 8 # Table 8 calls this NUM_MINI_EPOCHS
+"LR": 5.0e-5
+"LEARNING_STARTS": 10_000 # timesteps
+"LR_LINEAR_DECAY": False
+"GAMMA": 0.99
+"MIXER_EMBEDDING_DIM": 64
+"MIXER_HYPERNET_HIDDEN_DIM": 256
+"MIXER_INIT_SCALE": 0.001
+
+# ENV
+"ENV_NAME": "road_env"
+"ENV_KWARGS":
+  "map_name": "ToyExample-v2"
+  "encoding_type": "none"       # can be binary, one-hot, sinusoidal or none
+  "include_extra_observations":
+    "segment_lengths": True     # Length of the segments
+    "volumes": True             # Volumes of the vehicles on the segment normalized by the segment capacity
+    "capacity": False           # Capacity of the segments
+
+"REW_SCALE": 1e-9
+
+# evaluate
+"TEST_DURING_TRAINING": True
+"TEST_INTERVAL": 0.01 # as a fraction of updates
+"TEST_NUM_STEPS": 51
+"TEST_NUM_ENVS": 1000
+
+"ALG_NAME": "qmix_rnn"
+
+############ global params ############
+
+# experiment params
+"NUM_SEEDS": 1 # number of vmapped seeds
+"SEED": "random"
+
+"HYP_TUNE": False # perform hyp tune
+
+# wandb params
+"ENTITY": "imp-act"
+"PROJECT": "jaxMARL-qmix"
+"WANDB_MODE": "online"
+"WANDB_LOG_ALL_SEEDS": False # will log separately the vmapped seeds
+
+# checkpointing
+"SAVE_CHECKPOINTS": True # save checkpoints
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tipp: set to same value or fraction of TEST_INTERVAL.
+
+# precision
+"DOUBLE_PRECISION_MODE": False # use double precision for the environment
+
+# hydra params
+hydra:
+  run:
+    dir: outputs/${ENV_KWARGS.map_name}/${ALG_NAME}/${now:%Y-%m-%d_%H-%M-%S.%f}

--- a/experiments/config/pilot_runs/vdn_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/vdn_rnn_road_env.yaml
@@ -35,7 +35,7 @@
 # evaluate
 "TEST_DURING_TRAINING": True
 "TEST_INTERVAL": 0.01 # as a fraction of updates
-"TEST_NUM_STEPS": 51
+"TEST_NUM_STEPS": 50
 "TEST_NUM_ENVS": 1_000
 
 "ALG_NAME": "vdn_rnn"
@@ -56,7 +56,7 @@
 
 # checkpointing
 "SAVE_CHECKPOINTS": True # save checkpoints
-"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tipp: set to same value or fraction of TEST_INTERVAL.
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tip: set to same value or fraction of TEST_INTERVAL.
 
 # precision
 "DOUBLE_PRECISION_MODE": False # use double precision for the environment

--- a/experiments/config/pilot_runs/vdn_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/vdn_rnn_road_env.yaml
@@ -24,7 +24,7 @@
 "ENV_NAME": "road_env"
 "ENV_KWARGS":
   "map_name": "ToyExample-v2"
-  "encoding_type": "binary"     # can be binary, one-hot, sinusoidal or none
+  "encoding_type": "none"     # can be binary, one-hot, sinusoidal or none
   "include_extra_observations":
     "segment_lengths": True     # Length of the segments
     "volumes": True             # Volumes of the vehicles on the segment normalized by the segment capacity

--- a/experiments/config/pilot_runs/vdn_rnn_road_env.yaml
+++ b/experiments/config/pilot_runs/vdn_rnn_road_env.yaml
@@ -1,0 +1,67 @@
+# Convergence pilot for VDN on the IMP-act road env.
+# Hyperparameters from JaxMARL paper (Rutherford et al., NeurIPS 2024 D&B Track), 
+# Supplemental Table 8 ("Table 8: Q-Learning hyperparameters for MPE, SMAX and Overcooked")
+
+"TOTAL_TIMESTEPS": 50_000_000
+"NUM_ENVS": 16
+"NUM_STEPS": 128
+"BUFFER_SIZE": 5000
+"BUFFER_BATCH_SIZE": 32
+"HIDDEN_SIZE": 512
+"EPS_START": 1.0
+"EPS_FINISH": 0.05
+"EPS_DECAY": 0.1 # percentage of updates
+"MAX_GRAD_NORM": 10
+"TARGET_UPDATE_INTERVAL": 10
+"TAU": 1.0
+"NUM_EPOCHS": 8 # Table 8 calls this NUM_MINI_EPOCHS
+"LR": 5.0e-5
+"LEARNING_STARTS": 10_000 # timesteps
+"LR_LINEAR_DECAY": False
+"GAMMA": 0.99
+
+# ENV
+"ENV_NAME": "road_env"
+"ENV_KWARGS":
+  "map_name": "ToyExample-v2"
+  "encoding_type": "binary"     # can be binary, one-hot, sinusoidal or none
+  "include_extra_observations":
+    "segment_lengths": True     # Length of the segments
+    "volumes": True             # Volumes of the vehicles on the segment normalized by the segment capacity
+    "capacity": False           # Capacity of the segments
+
+"REW_SCALE": 1e-9
+
+# evaluate
+"TEST_DURING_TRAINING": True
+"TEST_INTERVAL": 0.01 # as a fraction of updates
+"TEST_NUM_STEPS": 51
+"TEST_NUM_ENVS": 1_000
+
+"ALG_NAME": "vdn_rnn"
+
+############ global params ############
+
+# experiment params
+"NUM_SEEDS": 1 # number of vmapped seeds
+"SEED": "random"
+
+"HYP_TUNE": False # perform hyp tune
+
+# wandb params
+"ENTITY": "imp-act"
+"PROJECT": "jaxMARL-vdn"
+"WANDB_MODE": "online"
+"WANDB_LOG_ALL_SEEDS": False # will log separately the vmapped seeds
+
+# checkpointing
+"SAVE_CHECKPOINTS": True # save checkpoints
+"SAVE_CHECKPOINTS_INTERVAL": 0.01 # as a fraction of updates. Tipp: set to same value or fraction of TEST_INTERVAL.
+
+# precision
+"DOUBLE_PRECISION_MODE": False # use double precision for the environment
+
+# hydra params
+hydra:
+  run:
+    dir: outputs/${ENV_KWARGS.map_name}/${ALG_NAME}/${now:%Y-%m-%d_%H-%M-%S.%f}

--- a/experiments/mappo_rnn_road_env.py
+++ b/experiments/mappo_rnn_road_env.py
@@ -979,9 +979,6 @@ def tune(default_config):
 
         # embedding size for the GRU, must be same as the GRU hidden size
         config["FC_HIDDEN_DIM"] = config["GRU_HIDDEN_DIM"]
-        config["TOTAL_TIMESTEPS"] = (
-            config["NUM_ENVS"] * config["NUM_STEPS"] * config["NUM_UPDATES"]
-        )
 
         if config["SEED"] == "random":
             seed = np.random.randint(0, 2**32 - 1)

--- a/experiments/pqn_vdn_rnn_road_env.py
+++ b/experiments/pqn_vdn_rnn_road_env.py
@@ -798,8 +798,6 @@ def tune(default_config):
         for k, v in dict(wandb.config).items():
             config[k] = v
 
-        config["TOTAL_TIMESTEPS"] = config["NUM_ENVS"] * config["NUM_STEPS"] * config["NUM_UPDATES"]
-
         if config["SEED"] == "random":
             seed = np.random.randint(0, 2**32 - 1)
             config["SAMPLED_SEED"] = seed

--- a/experiments/qmix_rnn_road_env.py
+++ b/experiments/qmix_rnn_road_env.py
@@ -862,8 +862,6 @@ def tune(default_config):
         for k, v in dict(wandb.config).items():
             config[k] = v
 
-        config["TOTAL_TIMESTEPS"] = config["NUM_ENVS"] * config["NUM_STEPS"] * config["NUM_UPDATES"]
-
         if config["SEED"] == "random":
             seed = np.random.randint(0, 2**32 - 1)
             config["SAMPLED_SEED"] = seed

--- a/experiments/vdn_rnn_road_env.py
+++ b/experiments/vdn_rnn_road_env.py
@@ -782,8 +782,6 @@ def tune(default_config):
         for k, v in dict(wandb.config).items():
             config[k] = v
 
-        config["TOTAL_TIMESTEPS"] = config["NUM_ENVS"] * config["NUM_STEPS"] * config["NUM_UPDATES"]
-
         if config["SEED"] == "random":
             seed = np.random.randint(0, 2**32 - 1)
             config["SAMPLED_SEED"] = seed

--- a/experiments/vdn_rnn_road_env.py
+++ b/experiments/vdn_rnn_road_env.py
@@ -10,6 +10,7 @@ import copy
 import jax
 import jax.numpy as jnp
 import numpy as np
+import logging
 from functools import partial
 from typing import NamedTuple, Dict, Union, Any
 
@@ -33,6 +34,9 @@ from jaxmarl.wrappers.baselines import (
     CTRolloutManager,
     save_params,
 )
+
+# Get Hydra's logger
+log = logging.getLogger(__name__)
 
 class ScannedRNN(nn.Module):
 
@@ -687,7 +691,7 @@ def make_train(config, env):
                 "metadata": metadata,
             }
 
-            print(f"Saving checkpoint {save_path}")
+            log.info(f"Saving checkpoint {save_path}")
             save_params(params_to_save, save_path)
 
         rng, _rng = jax.random.split(rng)
@@ -857,6 +861,7 @@ def main(config):
 
     if config.get("DOUBLE_PRECISION_MODE", False):
         jax.config.update("jax_enable_x64", True)
+        log.info("64 bit precision enabled")
 
     if config["HYP_TUNE"]:
         tune(config)


### PR DESCRIPTION
Introduce pilot run configurations for VDN and QMIX algorithms, updating the code to utilize total timesteps instead of the previous num updates. This change enhances the training process by standardizing the timestep calculations across different configurations.